### PR TITLE
fix: guard pkg/xattr flag constants undefined on Windows

### DIFF
--- a/memfilesystem.go
+++ b/memfilesystem.go
@@ -14,7 +14,6 @@ import (
 	"unsafe"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/pkg/xattr"
 
 	"github.com/ungerik/go-fs/fsimpl"
 )
@@ -914,11 +913,11 @@ func (fs *MemFileSystem) SetXAttr(filePath string, name string, data []byte, fla
 		return NewErrDoesNotExist(fs.RootDir().Join(filePath))
 	}
 	_, exists := node.XAttrs[name]
-	if flags&xattr.XATTR_CREATE != 0 && exists {
+	if flags&xattrCreate != 0 && exists {
 		fs.mtx.Unlock()
 		return fmt.Errorf("xattr %q already exists on %s", name, fs.RootDir().Join(filePath))
 	}
-	if flags&xattr.XATTR_REPLACE != 0 && !exists {
+	if flags&xattrReplace != 0 && !exists {
 		fs.mtx.Unlock()
 		return fmt.Errorf("xattr %q not found on %s", name, fs.RootDir().Join(filePath))
 	}

--- a/memfilesystem_test.go
+++ b/memfilesystem_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/xattr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -229,9 +228,9 @@ func TestMemFileSystem_FullFeatures(t *testing.T) {
 		require.Equal(t, []string{"user.other", "user.tag"}, names, "sorted keys")
 
 		// XATTR_CREATE rejects existing
-		require.Error(t, memFS.SetXAttr("/a.txt", "user.tag", []byte("new"), xattr.XATTR_CREATE, true))
+		require.Error(t, memFS.SetXAttr("/a.txt", "user.tag", []byte("new"), xattrCreate, true))
 		// XATTR_REPLACE rejects missing
-		require.Error(t, memFS.SetXAttr("/a.txt", "user.absent", []byte("z"), xattr.XATTR_REPLACE, true))
+		require.Error(t, memFS.SetXAttr("/a.txt", "user.absent", []byte("z"), xattrReplace, true))
 
 		// Remove and verify
 		require.NoError(t, memFS.RemoveXAttr("/a.txt", "user.tag", true))

--- a/xattrflags_supported.go
+++ b/xattrflags_supported.go
@@ -1,0 +1,16 @@
+//go:build linux || freebsd || netbsd || darwin || solaris
+
+package fs
+
+import "github.com/pkg/xattr"
+
+// xattrCreate and xattrReplace mirror the platform-specific
+// [xattr.XATTR_CREATE] and [xattr.XATTR_REPLACE] flag values so that
+// [MemFileSystem] interprets SetXAttr flags the same way the local file
+// system does. The pkg/xattr package only defines these constants on
+// platforms with native xattr support; see xattrflags_unsupported.go for
+// the fallback used on platforms without it (e.g. Windows).
+const (
+	xattrCreate  = xattr.XATTR_CREATE
+	xattrReplace = xattr.XATTR_REPLACE
+)

--- a/xattrflags_unsupported.go
+++ b/xattrflags_unsupported.go
@@ -1,0 +1,14 @@
+//go:build !linux && !freebsd && !netbsd && !darwin && !solaris
+
+package fs
+
+// xattrCreate and xattrReplace provide fallback values for platforms where
+// the pkg/xattr package has no native xattr support and therefore does not
+// define [xattr.XATTR_CREATE] / [xattr.XATTR_REPLACE] (e.g. Windows). The
+// values match the common Linux/Solaris constants and only affect
+// [MemFileSystem], the in-memory file system that implements xattrs on every
+// platform. The local file system has no xattr support on these platforms.
+const (
+	xattrCreate  = 0x1
+	xattrReplace = 0x2
+)


### PR DESCRIPTION
## What

Make the package and all its submodules build on Windows (theoretically) by removing direct references to `github.com/pkg/xattr` flag constants that don't exist on every platform.

## Why

`github.com/pkg/xattr` only defines `XATTR_CREATE` / `XATTR_REPLACE` on platforms with native xattr support (`linux`, `darwin`, `freebsd`, `netbsd`, `solaris`). On other platforms (e.g. Windows) its `xattr_unsupported.go` declares only `XATTR_SUPPORTED = false` and stub functions — no flag constants.

`memfilesystem.go` referenced `xattr.XATTR_CREATE` / `xattr.XATTR_REPLACE` directly, so `GOOS=windows go build` failed:

```
./memfilesystem.go:917:17: undefined: xattr.XATTR_CREATE
./memfilesystem.go:921:17: undefined: xattr.XATTR_REPLACE
```

This broke the root module **and every submodule that depends on it** (`dropboxfs`, `ftpfs`, `s3fs`, `sftpfs`) on Windows.

## How

- Add package-local `xattrCreate` / `xattrReplace` constants via two complementary build-tagged files:
  - `xattrflags_supported.go` (`linux || freebsd || netbsd || darwin || solaris`) — aliases the real `xattr.XATTR_CREATE` / `xattr.XATTR_REPLACE`, preserving the existing per-platform flag values so the in-memory FS interprets the same bits a caller passes to the local FS.
  - `xattrflags_unsupported.go` (the exact negation) — fallback `0x1` / `0x2`, only ever consumed by the in-memory `MemFileSystem` (the only xattr-capable FS on those platforms).
- `memfilesystem.go` and `memfilesystem_test.go` now use the local constants and drop the `github.com/pkg/xattr` import.

The build tags are exact complements, so exactly one file compiles per platform — no gaps, no overlap. `localfilesystem.go` needed no change: it only calls xattr *functions*, which the package stubs on all platforms.

## Verification

- `GOOS=windows GOARCH=amd64 go vet ./...` (compiles tests too) — clean for the root module and all four FS submodules.
- `GOOS=linux` / native `darwin` builds and the full native `go test ./...` suite still pass, including the `MemFileSystem` xattr `CREATE` / `REPLACE` flag tests.
